### PR TITLE
feat: support TypeScript 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:8
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+      - run: yarn install
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+      - run: yarn test
+      - run: yarn lint

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ After installing, you can use `module-analyzr` command in any directory in your 
 
   Options:
     -i   File path or directory path or glob pattern to ignore. Default: [node_modules]
-
+    -type    "typescript" | "flow"
 
 # example and output
 module-analyzr react src/**/*.js

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ After installing, you can use `module-analyzr` command in any directory in your 
 
   Options:
     -i   File path or directory path or glob pattern to ignore. Default: [node_modules]
-    -type    "typescript" | "flow"
+    -typescript  passes typescript plugin to the parser
+    -flow  passes flow plugin to the parser
 
 # example and output
 module-analyzr react src/**/*.js

--- a/bin.js
+++ b/bin.js
@@ -15,7 +15,8 @@ const showHelp = () => {
 
     Options:
       -i   File path or directory path or glob pattern to ignore. Default: [node_modules]
-      -type   "typescript" | "flow"
+      -typescript  passes typescript plugin to the parser
+      -flow  passes flow plugin to the parser
   `)
 }
 

--- a/bin.js
+++ b/bin.js
@@ -15,6 +15,7 @@ const showHelp = () => {
 
     Options:
       -i   File path or directory path or glob pattern to ignore. Default: [node_modules]
+      -type   "typescript" | "flow"
   `)
 }
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = (pkgName, path, options) => {
   
   files.forEach(file => {
     const data = fs.readFileSync(file, 'utf8')
-    const ast = parser(data)
+    const ast = parser(data, options)
     const importData = extractStatement(ast, pkgName)
     
     // TODO: extract to function

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
   },
   "author": "ynakamura <ynakamura.vla@gmail.com>",
   "homepage": "https://github.com/taneba/module-analyzr",
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/taneba/module-analyzr"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/taneba/module-analyzr"
   },
   "license": "MIT",
   "dependencies": {
-    "@babel/parser": "7.0.0-beta.48",
+    "@babel/parser": "7.4.3",
     "colo": "0.3.2",
     "glob": "7.1.2",
     "is-glob": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "colo": "0.3.2",
     "glob": "7.1.2",
     "is-glob": "4.0.0",
-    "lodash": "4.17.10",
+    "lodash": "4.17.11",
     "minimist": "1.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "colo": "0.3.2",
     "glob": "7.1.2",
     "is-glob": "4.0.0",
-    "lodash": "4.17.11",
+    "lodash": "4.17.10",
     "minimist": "1.2.0"
   },
   "devDependencies": {

--- a/parser.js
+++ b/parser.js
@@ -5,17 +5,25 @@ const babylon = require('@babel/parser')
  * returns ast parsed by babylon
  * @param {string} code 
  */
-module.exports = code => {
+module.exports = (code, options) => {
+  const plugins = [
+    "jsx",
+    "objectRestSpread",
+    "classProperties",
+    "flowComments",
+    "dynamicImport"
+  ]
+  if(options.type){
+    if(options.type === 'flow') {
+      plugins.unshift('flow')
+    }
+    if(options.type === 'typescript') {
+      plugins.unshift('typescript')
+    }
+  }
+
   return babylon.parse(code, {
     sourceType: "module",
-
-    plugins: [
-      // enable jsx and flow syntax
-      "jsx",
-      "flow",
-      "objectRestSpread",
-      "classProperties",
-      "flowComments",
-      "dynamicImport"
-    ]  })
+    plugins: plugins 
+  })
 }

--- a/parser.js
+++ b/parser.js
@@ -13,15 +13,12 @@ module.exports = (code, options) => {
     "flowComments",
     "dynamicImport"
   ]
-  if(options.type){
-    if(options.type === 'flow') {
-      plugins.unshift('flow')
-    }
-    if(options.type === 'typescript') {
-      plugins.unshift('typescript')
-    }
+  if(options.flow){
+    plugins.unshift('flow')
   }
-
+  if(options.typescript) {
+    plugins.unshift('typescript')
+  }
   return babylon.parse(code, {
     sourceType: "module",
     plugins: plugins 

--- a/test/fixtures/require-statement.js
+++ b/test/fixtures/require-statement.js
@@ -3,4 +3,4 @@ import * as name from "test-module";
 import { export as alias } from "test-module";
 
 import { export1, export2 } from "test-module";
-import { export1 } from "test-module";
+import { export3 } from "test-module";

--- a/test/fixtures/ts-project/index.ts
+++ b/test/fixtures/ts-project/index.ts
@@ -1,0 +1,27 @@
+import defaultExport from "test-module";
+import * as name from "test-module";
+import { export as alias } from "test-module";
+
+import { export1, export2 } from "test-module";
+import { export3 } from "test-module";
+
+interface Person {
+  firstName: string;
+  lastName: string;
+}
+
+function greeter(person: Person) {
+  return "Hello, " + person.firstName + " " + person.lastName;
+}
+
+// class
+class Student {
+  fullName: string;
+  constructor(public firstName: string, public middleInitial: string, public lastName: string) {
+      this.fullName = firstName + " " + middleInitial + " " + lastName;
+  }
+}
+
+let user = new Student("Jane", "M.", "User");
+
+document.body.innerHTML = greeter(user);

--- a/test/fixtures/ts-project/react.tsx
+++ b/test/fixtures/ts-project/react.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+
+export interface HelloProps { compiler: string; framework: string; }
+
+// 'HelloProps' describes the shape of props.
+// State is never set so we use the '{}' type.
+export class Hello extends React.Component<HelloProps, {}> {
+    render() {
+        return <h1>Hello from {this.props.compiler} and {this.props.framework}!</h1>;
+    }
+}

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -48,7 +48,7 @@ describe('module-analyzr', () => {
   it('should parse typescript files', () => {
     const fixture = path.join(__dirname, './fixtures/ts-project')
 
-    expect(analyzer('test-module', fixture, {type: 'typescript'})).toEqual({
+    expect(analyzer('test-module', fixture, {typescript: true})).toEqual({
       importedModules: [
         { moduleName: 'export', usageAmount: 1 },
         { moduleName: 'export1', usageAmount: 1 },

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -8,8 +8,9 @@ describe('module-analyzr', () => {
     expect(analyzer('test-module', fixture)).toEqual({
       importedModules: [
         { moduleName: 'export', usageAmount: 1 },
-        { moduleName: 'export1', usageAmount: 2 },
-        { moduleName: 'export2', usageAmount: 1 }
+        { moduleName: 'export1', usageAmount: 1 },
+        { moduleName: 'export2', usageAmount: 1 },
+        { moduleName: 'export3', usageAmount: 1 }
       ],
       importedDefault: 1,
       importedWithNameSpace: 1
@@ -35,10 +36,26 @@ describe('module-analyzr', () => {
     expect(analyzer('test-module', fixture)).toEqual({
       importedModules: [
         { moduleName: 'export', usageAmount: 1 },
-        { moduleName: 'export1', usageAmount: 4 },
-        { moduleName: 'export2', usageAmount: 3 }
+        { moduleName: 'export1', usageAmount: 3 },
+        { moduleName: 'export2', usageAmount: 3 },
+        { moduleName: 'export3', usageAmount: 1 }
       ],
       importedDefault: 2,
+      importedWithNameSpace: 1
+    })
+  })
+
+  it('should parse typescript files', () => {
+    const fixture = path.join(__dirname, './fixtures/ts-project')
+
+    expect(analyzer('test-module', fixture, {type: 'typescript'})).toEqual({
+      importedModules: [
+        { moduleName: 'export', usageAmount: 1 },
+        { moduleName: 'export1', usageAmount: 1 },
+        { moduleName: 'export2', usageAmount: 1 },
+        { moduleName: 'export3', usageAmount: 1 }
+      ],
+      importedDefault: 1,
       importedWithNameSpace: 1
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,9 +16,9 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@babel/parser@7.0.0-beta.48":
-  version "7.0.0-beta.48"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.0.0-beta.48.tgz#f93895cbacee703c0ec98e5af3901c77edd9f1d7"
+"@babel/parser@7.4.3":
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.3.tgz#eb3ac80f64aa101c907d4ce5406360fe75b7895b"
 
 abab@^1.0.4:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2294,7 +2294,11 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@4.17.10, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.3.0:
+lodash@4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+
+lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 


### PR DESCRIPTION
closes #5 

This PR enables to parse typescript with -type option.

## breaking change
Since babel cannot combine flow and typescript plugins, the flow plugin is now optional.